### PR TITLE
Handle session item acts with broken urls

### DIFF
--- a/otvoreni_akti/apps/scraper_rijeka/scrape_utils.py
+++ b/otvoreni_akti/apps/scraper_rijeka/scrape_utils.py
@@ -94,7 +94,7 @@ def scrape_session(scraper_period):
 
     for item_no, section in enumerate(sections, start=1):
         print(f'Scraping item {item_no}  from Grad Rijeka for {scraper_period.period_text}')
-        item_title = f'#{item_no} - {period}'
+        item_title = f'#{item_no} - {period}'[:99] 
         if not Item.objects.filter(item_title=item_title).exists():
             item = Item.objects.create(
                 period=period,

--- a/otvoreni_akti/apps/scraper_rijeka/scrape_utils.py
+++ b/otvoreni_akti/apps/scraper_rijeka/scrape_utils.py
@@ -111,6 +111,9 @@ def scrape_session(scraper_period):
             full_url = document.a['href']
             title = document.a.get_text(strip=True)
 
+            if not full_url.startswith("http"): # there are some broken items
+                continue
+
             # create Subject object
             if not Subject.objects.filter(subject_url=full_url).exists():
                 subject = Subject.objects.create(


### PR DESCRIPTION
There are a few instances of acts with broken links (empty URLs) and malformed session name resulting in overly long item names.

