### PR TITLE
add setting to adapt search and UI to a single city

### DIFF
--- a/otvoreni_akti/apps/search/templates/search/search_home.html
+++ b/otvoreni_akti/apps/search/templates/search/search_home.html
@@ -26,38 +26,40 @@
         {% url 'about' as about %}
         {% if request.get_full_path != about %}
             <form method="get" action="{% url 'search_results' %}">
-                <div class="search_metadata cities">
-                    <button class="city-selector"
-                            id="all"
-                            type="button"
-                            value="All"
-                            onclick="selectCity(this.value, this.id)">
-                        Svi
-                    </button>
-                    <button class="city-selector"
-                            id="zagreb"
-                            type="button"
-                            value="Zagreb"
-                            onclick="selectCity(this.value, this.id)">
-                        Zagreb
-                    </button>
-                    <button class="city-selector"
-                            id="split"
-                            type="button"
-                            value="Split"
-                            onclick="selectCity(this.value, this.id)">
-                        Split
-                    </button>
-                    <button class="city-selector"
-                            id="rijeka"
-                            type="button"
-                            value="Rijeka"
-                            onclick="selectCity(this.value, this.id)">
-                        Rijeka
-                    </button>
-                    <input type='text' id="city" name="city">
-                </div>
-            
+                {% if SHOW_CITY_SELECTOR %}
+                    <div class="search_metadata cities">
+                        <button class="city-selector"
+                                id="all"
+                                type="button"
+                                value="All"
+                                onclick="selectCity(this.value, this.id)">
+                            Svi
+                        </button>
+                        <button class="city-selector"
+                                id="zagreb"
+                                type="button"
+                                value="Zagreb"
+                                onclick="selectCity(this.value, this.id)">
+                            Zagreb
+                        </button>
+                        <button class="city-selector"
+                                id="split"
+                                type="button"
+                                value="Split"
+                                onclick="selectCity(this.value, this.id)">
+                            Split
+                        </button>
+                        <button class="city-selector"
+                                id="rijeka"
+                                type="button"
+                                value="Rijeka"
+                                onclick="selectCity(this.value, this.id)">
+                            Rijeka
+                        </button>
+                        <input type='text' id="city" name="city">
+                    </div>
+                {% endif %}
+
                 <!-- Search Bar -->
                 <div class="search_bar">
                     <button type="submit">
@@ -171,14 +173,14 @@
                  oldSelection.removeAttribute("id");
                  oldSelection.id = oldSelection.value.toLowerCase();
              };
-             
+
              <!-- set "selected-city" id for newly selected city to apply styling -->
              document.getElementById(element_id).id = "selected-city";
          }
 
          function getSelectedCity() {
              <!-- return city value for search -->
-             
+
              let match = RegExp('[?&]' + 'city' + '=([^&]*)').exec(window.location.search);
              let queryParamCity = match && decodeURIComponent(match[1].replace(/\+/g, ' '));
              let inputCityValue = document.getElementById("city").value;
@@ -195,7 +197,7 @@
          };
 
          let selectedCity = getSelectedCity();
-         
+
          <!-- on page load set city selector to selected value -->
          document.addEventListener(
              'DOMContentLoaded',

--- a/otvoreni_akti/context_processors.py
+++ b/otvoreni_akti/context_processors.py
@@ -1,0 +1,7 @@
+from otvoreni_akti.settings import SINGLE_CITY_SCOPE
+
+
+def template_settings(request):
+    return {
+        'SHOW_CITY_SELECTOR': not SINGLE_CITY_SCOPE,
+    }

--- a/otvoreni_akti/settings.py
+++ b/otvoreni_akti/settings.py
@@ -100,6 +100,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'otvoreni_akti.context_processors.template_settings'
             ],
         },
     },
@@ -208,3 +209,8 @@ RESCRAPE_LAST_N_PERIODS = 5
 MAX_SEARCH_RESULTS = 1000
 RESULTS_PER_PAGE = 20
 SEARCH_REQUEST_TIMEOUT = 30     # In seconds
+
+# To enable single city search, assign city name to SINGLE_CITY_SCOPE, e.g.:
+# SINGLE_CITY_SCOPE = 'Rijeka'
+# if SINGLE_CITY_SCOPE is None or '', city selector UI will be displayed
+SINGLE_CITY_SCOPE = 'Rijeka'


### PR DESCRIPTION
In order to simplify integration with official web pages of supported cities, a new setting `SINGLE_CITY_SCOPE` is introduced.

Setting the value of `settings.SINGLE_CITY_SCOPE` to a city name (`Rijeka`, `Zagreb`, `Split`) will:
* remove the city selector UI from search page
* modify the search query to search only the documents for the specified city